### PR TITLE
Feat: SEO 메타데이터 설정 및 태그 뱃지 UI 추가

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,14 +3,46 @@ import "./globals.css";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
 
+const SITE_URL = "https://zerowoosik.github.io";
+const SITE_TITLE = "zerowoosik's Blog";
+const SITE_DESCRIPTION =
+  "소프트웨어 개발 경험과 기술적 문제 해결을 기록하는 기술 블로그입니다.";
+
 export const metadata: Metadata = {
-  title: "zerowoosik's Blog",
-  description:
-    "zerowoosik의 github 기술 블로그입니다. 해당 블로그는 Antigravity를 이용하여 제작되었습니다.",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: SITE_TITLE,
+    template: `%s | ${SITE_TITLE}`,
+  },
+  description: SITE_DESCRIPTION,
+  keywords: ["개발", "기술 블로그", "프로그래밍", "소프트웨어", "zerowoosik"],
+  authors: [{ name: "zerowoosik", url: SITE_URL }],
   openGraph: {
-    title: "zerowoosik's Blog",
-    description: "zerowoosik의 github 기술 블로그입니다. 해당 블로그는 Antigravity를 이용하여 제작되었습니다.",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    url: SITE_URL,
+    siteName: SITE_TITLE,
     type: "website",
+    locale: "ko_KR",
+  },
+  twitter: {
+    card: "summary",
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-snippet": -1,
+      "max-image-preview": "large",
+      "max-video-preview": -1,
+    },
+  },
+  alternates: {
+    canonical: SITE_URL,
   },
 };
 

--- a/app/posts/[slug]/PostDetailClient.tsx
+++ b/app/posts/[slug]/PostDetailClient.tsx
@@ -36,12 +36,7 @@ export function PostDetailClient({ post }: PostDetailClientProps) {
                         <h1 className="text-3xl md:text-4xl font-bold text-text-white mb-4 leading-tight">
                             {post.title}
                         </h1>
-                        {post.description && (
-                            <p className="text-lg text-text-muted mb-6">
-                                {post.description}
-                            </p>
-                        )}
-                        <div className="flex items-center text-sm text-text-muted space-x-6 font-medium">
+                        <div className="flex items-center text-sm text-text-muted space-x-6 font-medium mb-4">
                             <span className="flex items-center">
                                 <span className="material-symbols-outlined text-base mr-1.5">
                                     Create
@@ -49,6 +44,18 @@ export function PostDetailClient({ post }: PostDetailClientProps) {
                                 {post.date}
                             </span>
                         </div>
+                        {post.tags && post.tags.length > 0 && (
+                            <div className="flex flex-wrap gap-2">
+                                {post.tags.map((tag) => (
+                                    <span
+                                        key={tag}
+                                        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20"
+                                    >
+                                        #{tag}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
                     </header>
 
                     <article

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -14,14 +14,27 @@ export async function generateStaticParams() {
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     const { slug } = await params;
     const post = await getPostData(slug);
+    const postUrl = `https://zerowoosik.github.io/posts/${slug}`;
+
     return {
-        title: `${post.title} | zerowoosik's Blog`,
+        title: post.title,
         description: post.description,
+        keywords: post.tags,
         openGraph: {
             title: post.title,
             description: post.description,
+            url: postUrl,
             type: "article",
             publishedTime: post.date,
+            authors: ["zerowoosik"],
+        },
+        twitter: {
+            card: "summary",
+            title: post.title,
+            description: post.description,
+        },
+        alternates: {
+            canonical: postUrl,
         },
     };
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: [
+            {
+                userAgent: "*",
+                allow: "/",
+            },
+        ],
+        sitemap: "https://zerowoosik.github.io/sitemap.xml",
+    };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+import { getSortedPostsData } from "@/lib/posts";
+
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    const posts = getSortedPostsData();
+    const baseUrl = "https://zerowoosik.github.io";
+
+    const postEntries: MetadataRoute.Sitemap = posts.map((post) => ({
+        url: `${baseUrl}/posts/${post.slug}`,
+        lastModified: new Date(post.date),
+        changeFrequency: "monthly",
+        priority: 0.8,
+    }));
+
+    return [
+        {
+            url: baseUrl,
+            lastModified: new Date(),
+            changeFrequency: "weekly",
+            priority: 1.0,
+        },
+        ...postEntries,
+    ];
+}

--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -15,9 +15,18 @@ export function PostCard({ post }: PostCardProps) {
                 <h2 className="text-xl font-bold mb-2 text-text-white group-hover:text-primary transition-colors duration-200">
                     {post.title}
                 </h2>
-                <p className="text-text-muted text-sm leading-relaxed">
-                    {post.description}
-                </p>
+                {post.tags && post.tags.length > 0 && (
+                    <div className="flex flex-wrap gap-1.5 mt-3">
+                        {post.tags.map((tag) => (
+                            <span
+                                key={tag}
+                                className="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20"
+                            >
+                                #{tag}
+                            </span>
+                        ))}
+                    </div>
+                )}
             </article>
         </Link>
     );


### PR DESCRIPTION
- sitemap.xml, robots.txt 자동 생성
- 포스트별 동적 메타데이터 적용 (og, twitter, canonical)
- 포스트 카드 및 상세 페이지에 태그 뱃지 UI 추가
- Material Symbols 폰트 중복 로드 제거